### PR TITLE
Excel close error "The given key was not present in the dictionary."

### DIFF
--- a/src/VSTOContrib.Excel/RibbonFactory/ExcelViewProvider.cs
+++ b/src/VSTOContrib.Excel/RibbonFactory/ExcelViewProvider.cs
@@ -34,15 +34,18 @@ namespace VSTOContrib.Excel.RibbonFactory
             var handler = ViewClosed;
             if (handler == null) return;
 
-            var windows = workbooks[e.Workbook];
-
-            foreach (var window in windows)
+            if (workbooks.ContainsKey(e.Workbook))
             {
-                handler(this, new ViewClosedEventArgs(window, e.Workbook));
-                if (!IsMdi())
-                    window.ReleaseComObject();
+                var windows = workbooks[e.Workbook];
+
+                foreach (var window in windows)
+                {
+                    handler(this, new ViewClosedEventArgs(window, e.Workbook));
+                    if (!IsMdi())
+                        window.ReleaseComObject();
+                }
+                workbooks.Remove(e.Workbook);
             }
-            workbooks.Remove(e.Workbook);
         }
 
         /// <summary>


### PR DESCRIPTION
This is a fix for an error I get when the workbook that is closing is not found in the workbooks dictionary.  I checked for any hanging Excel processes and found none, so I'm going to commit and submit a pull request.
