### PR TITLE
Changed Initialise in ExcelViewProvider to handle WorkbookOpen

### DIFF
--- a/src/VSTOContrib.Excel/RibbonFactory/ExcelViewProvider.cs
+++ b/src/VSTOContrib.Excel/RibbonFactory/ExcelViewProvider.cs
@@ -53,10 +53,11 @@ namespace VSTOContrib.Excel.RibbonFactory
         /// </summary>
         public void Initialise()
         {
-            ((AppEvents_Event)excelApplication).NewWorkbook += OnNewWorkbook;
+            ((AppEvents_Event)excelApplication).NewWorkbook += OnInitialise;
+            ((AppEvents_Event)excelApplication).WorkbookOpen += OnInitialise;
         }
 
-        void OnNewWorkbook(Workbook wb)
+        void OnInitialise(Workbook wb)
         {
             var handler = NewView;
             if (handler == null) return;
@@ -150,7 +151,7 @@ namespace VSTOContrib.Excel.RibbonFactory
         {
             foreach (var wb in excelApplication.Workbooks.ComLinq<Workbook>())
             {
-                OnNewWorkbook(wb);
+                OnInitialise(wb);
             }
         }
     }


### PR DESCRIPTION
This should resolve issue #12  and #16 

Added event handler for WorkbookOpen.  Taskpanes are currently not registered on opening an existing workbook.  Any check in a ViewModel using VSTOContrib returns a taskpane as null, e.g. visibility this should fix that issue.  Refactored OnNewWorkbook to OnInitialise for consistency.  I didn't find any issues testing it on my side. 
