### PR TITLE
Added handling for group's getHelperText element in backstage view

### DIFF
--- a/src/VSTOContrib.Core/RibbonFactory/RibbonFactory.cs
+++ b/src/VSTOContrib.Core/RibbonFactory/RibbonFactory.cs
@@ -432,5 +432,15 @@ namespace VSTOContrib.Core.RibbonFactory
         {
             ribbonFactoryController.Invoke(control, () => OnTextChanged(null, null), text);
         }
+
+        /// <summary>
+        /// GetHelperText callback
+        /// </summary>
+        /// <param name="control">The control</param>
+        /// <returns></returns>
+        public string GetHelperText(IRibbonControl control)
+        {
+            return (string)ribbonFactoryController.InvokeGet(control, () => GetHelperText(null));
+        }
     }
 }

--- a/src/VSTOContrib.Core/RibbonFactory/RibbonFactoryController.cs
+++ b/src/VSTOContrib.Core/RibbonFactory/RibbonFactoryController.cs
@@ -351,7 +351,12 @@ namespace VSTOContrib.Core.RibbonFactory
                                                               {"getDescription", f => f.GetDescription(null)}
                                                           }
                        },
-                       {"group", new Dictionary<string, Expression<Action<RibbonFactory>>>()},
+                       {
+                           "group", new Dictionary<string, Expression<Action<RibbonFactory>>>
+                                    {
+                                        {"getHelperText", f => f.GetHelperText(null)}
+                                    }
+                       },
                        {"tab", new Dictionary<string, Expression<Action<RibbonFactory>>>()},
                        {
                            "button", new Dictionary<string, Expression<Action<RibbonFactory>>>


### PR DESCRIPTION
This commit adds support for binding getHelperText attribute in group element for Backstage view

``` xml
 <backstage>
    <tab id="MyBackstageTab" label="Backstage" >
      <firstColumn>
        <group id="Settings" label="Addin settings" getHelperText="GetSettingsHelperText" />
      </firstColumn>
    </tab>
</backstage>
```
