### PR TITLE
Check ribbonTaskPanes to see if it contains the view model before trying to retrieve the view model.

### DIFF
--- a/src/VSTOContrib.Core/RibbonFactory/Internal/CustomTaskPaneRegister.cs
+++ b/src/VSTOContrib.Core/RibbonFactory/Internal/CustomTaskPaneRegister.cs
@@ -104,6 +104,7 @@ namespace VSTOContrib.Core.RibbonFactory.Internal
 
         public void CleanupViewModel(IRibbonViewModel viewModelInstance)
         {
+            if (!ribbonTaskPanes.ContainsKey(viewModelInstance)) return;
             var adaptersForViewModel = ribbonTaskPanes[viewModelInstance];
             ribbonTaskPanes.Remove(viewModelInstance);
             foreach (var oneToManyCustomTaskPaneAdapter in adaptersForViewModel)


### PR DESCRIPTION
Check ribbonTaskPanes to see if it contains the view model before trying to retrieve the view model.
