### PR TITLE
Remember first RibbonUI in DefaultRibbon

### DIFF
--- a/src/VSTOContrib.Core/RibbonFactory/Internal/ViewModelResolver.cs
+++ b/src/VSTOContrib.Core/RibbonFactory/Internal/ViewModelResolver.cs
@@ -154,6 +154,11 @@ namespace VSTOContrib.Core.RibbonFactory.Internal
                 viewModelLookup.RibbonUi = ribbonUi;
                 InvalidateRibbonForViewModel(viewModelLookup);
             }
+
+            if (!ribbonUiLookup.ContainsKey(DefaultRibbon))
+            {
+                ribbonUiLookup[DefaultRibbon] = ribbonUi;
+            }
         }
 
         private IRibbonViewModel BuildViewModel(string ribbonType, object viewInstance, object viewContext)


### PR DESCRIPTION
It should fix another cornercase with `Ribbon_Load` firing only once. 
It helps when `Ribbon_Load` fires once it context of some `ribbonType` (we were remembering it's `RibbonUI` in `RibbonUILookup` with that `ribbonType` key) and then when we're loading another ribbon - `Ribbon_Load` event is not fired again, so we won't have `RibbonUI` for this `ribbonType` in `RibbonUILookup`. The solution is to remember first `RibbonUI` as `DefaultRibbon` and use it when there's no ribbon under specific key in `RibbonUILookup`.

Fixes #44
