### PR TITLE
VstoContribContext ErrorHandlers null bug fix

### DIFF
--- a/src/VSTOContrib.Core/RibbonFactory/RibbonFactory.cs
+++ b/src/VSTOContrib.Core/RibbonFactory/RibbonFactory.cs
@@ -84,10 +84,14 @@ namespace VSTOContrib.Core.RibbonFactory
             }
         }
 
-        public List<IErrorHandler> ErrorHandlers
+        /// <summary>
+        /// Gets collection of registered global error handlers. New custom IErrorHandler implementation can be added in collection.
+        /// </summary>
+        public ICollection<IErrorHandler> ErrorHandlers
         {
             get { return context.ErrorHandlers; }
         }
+
         /// <summary>
         /// Called when the add-in is shutting down
         /// </summary>

--- a/src/VSTOContrib.Core/RibbonFactory/VstoContribContext.cs
+++ b/src/VSTOContrib.Core/RibbonFactory/VstoContribContext.cs
@@ -27,6 +27,7 @@ namespace VSTOContrib.Core.RibbonFactory
             ViewModelFactory = new DefaultViewModelFactory();
             RibbonXmlFromTypeLookup = new Dictionary<string, string>();
             TagToCallbackTargetLookup = new Dictionary<string, CallbackTarget>();
+            ErrorHandlers = new List<IErrorHandler>();
         }
 
         public Assembly[] Assemblies { get; set; }
@@ -52,7 +53,7 @@ namespace VSTOContrib.Core.RibbonFactory
 
         public Factory VstoFactory { get; private set; }
         public string FallbackRibbonType { get; private set; }
-        public List<IErrorHandler> ErrorHandlers { get; private set; }
+        public ICollection<IErrorHandler> ErrorHandlers { get; private set; }
         public IViewModelFactory ViewModelFactory { get; set; }
     }
 }


### PR DESCRIPTION
ErrorHandlers property initialization added in constructor of VstoContribContext internal class.

Changed property type from List<IErrorHandler> -> ICollection<IErrorHandler>
