### PR TITLE
RibbonFactory IViewLocationStrategy bug fix (default loaded only once, changing it has no effect)

### DIFF
--- a/src/TestProjects/VSTOContrib.Core.Tests/RibbonFactory/TestStubs/TestRibbonFactory.cs
+++ b/src/TestProjects/VSTOContrib.Core.Tests/RibbonFactory/TestStubs/TestRibbonFactory.cs
@@ -14,14 +14,26 @@ namespace VSTOContrib.Core.Tests.RibbonFactory.TestStubs
             IViewContextProvider contextProvider,
             string fallbackRibbonType,
             params Assembly[] assemblies)
-            : base(addInBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), contextProvider, fallbackRibbonType)
+            : base(addInBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), contextProvider, null, fallbackRibbonType)
+        {
+            this.viewProvider = viewProvider;
+        }
+
+        public TestRibbonFactory(
+            AddInBase addInBase,
+            IViewProvider viewProvider,
+            IViewContextProvider contextProvider,
+            IViewLocationStrategy viewLocationStrategy,
+            string fallbackRibbonType,
+            params Assembly[] assemblies)
+            : base(addInBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), contextProvider, viewLocationStrategy, fallbackRibbonType)
         {
             this.viewProvider = viewProvider;
         }
 
         protected override void ShuttingDown()
         {
-            
+
         }
 
         protected override void InitialiseRibbonFactoryController(IRibbonFactoryController controller, object application)

--- a/src/VSTOContrib.Core/RibbonFactory/Interfaces/IRibbonFactory.cs
+++ b/src/VSTOContrib.Core/RibbonFactory/Interfaces/IRibbonFactory.cs
@@ -8,10 +8,10 @@ namespace VSTOContrib.Core.RibbonFactory.Interfaces
     public interface IRibbonFactory : IRibbonExtensibility
     {
         /// <summary>
-        /// Gets or sets the locate view strategy.
+        /// Gets the locate view strategy.
         /// </summary>
         /// <value>The locate view strategy.</value>
-        IViewLocationStrategy LocateViewStrategy { get; set; }
+        IViewLocationStrategy LocateViewStrategy { get; }
 
         /// <summary>
         /// Gets or sets the view model factory, default uses Activator.CreateInstance

--- a/src/VSTOContrib.Core/RibbonFactory/RibbonFactory.cs
+++ b/src/VSTOContrib.Core/RibbonFactory/RibbonFactory.cs
@@ -25,13 +25,13 @@ namespace VSTOContrib.Core.RibbonFactory
         readonly VstoContribContext context;
 
         protected RibbonFactory(
-            AddInBase addinBase, Assembly[] assemblies, IViewContextProvider contextProvider,
+            AddInBase addinBase, Assembly[] assemblies, IViewContextProvider contextProvider, IViewLocationStrategy viewLocationStrategy,
             [CanBeNull] string fallbackRibbonType)
         {
             if (assemblies.Length == 0)
                 throw new InvalidOperationException("You must specify at least one assembly to scan for viewmodels");
 
-            context = new VstoContribContext(assemblies, addinBase, fallbackRibbonType);
+            context = new VstoContribContext(assemblies, addinBase, fallbackRibbonType, viewLocationStrategy);
             ribbonFactoryController = new RibbonFactoryController(contextProvider, context);
 
             addinBase.Startup += AddinBaseOnStartup;
@@ -43,7 +43,7 @@ namespace VSTOContrib.Core.RibbonFactory
             if (assemblies.Length > 0)
                 return assemblies;
 
-            return new[] {fallback};
+            return new[] { fallback };
         }
 
         void AddinBaseOnStartup(object sender, EventArgs eventArgs)
@@ -67,11 +67,6 @@ namespace VSTOContrib.Core.RibbonFactory
         public IViewLocationStrategy LocateViewStrategy
         {
             get { return context.ViewLocationStrategy; }
-            set
-            {
-                if (value == null) return;
-                context.ViewLocationStrategy = value;
-            }
         }
 
         public IViewModelFactory ViewModelFactory

--- a/src/VSTOContrib.Core/RibbonFactory/VstoContribContext.cs
+++ b/src/VSTOContrib.Core/RibbonFactory/VstoContribContext.cs
@@ -13,7 +13,7 @@ namespace VSTOContrib.Core.RibbonFactory
         readonly Type addinType;
         object application;
 
-        public VstoContribContext(Assembly[] assemblies, AddInBase addinBase, string fallbackRibbonType)
+        public VstoContribContext(Assembly[] assemblies, AddInBase addinBase, string fallbackRibbonType, IViewLocationStrategy viewLocationStrategy = null)
         {
             FallbackRibbonType = fallbackRibbonType;
             Assemblies = assemblies;
@@ -24,7 +24,7 @@ namespace VSTOContrib.Core.RibbonFactory
             var factory = globalsType.GetProperty("Factory", BindingFlags.Static | BindingFlags.NonPublic)
                 .GetValue(null, null);
             VstoFactory = (Factory)factory;
-            ViewLocationStrategy = new DefaultViewLocationStrategy();
+            ViewLocationStrategy = viewLocationStrategy ?? new DefaultViewLocationStrategy();
             ViewModelFactory = new DefaultViewModelFactory();
             RibbonXmlFromTypeLookup = new Dictionary<string, string>();
             TagToCallbackTargetLookup = new Dictionary<string, CallbackTarget>();

--- a/src/VSTOContrib.Excel/RibbonFactory/ExcelRibbonFactory.cs
+++ b/src/VSTOContrib.Excel/RibbonFactory/ExcelRibbonFactory.cs
@@ -12,14 +12,22 @@ namespace VSTOContrib.Excel.RibbonFactory
     {
         ExcelViewProvider excelViewProvider;
 
-        public ExcelRibbonFactory(AddInBase addinBase, params Assembly[] assemblies)
-            : base(addinBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), new ExcelViewContextProvider(), ExcelRibbonType.ExcelWorkbook.GetEnumDescription())
+        public ExcelRibbonFactory(AddInBase addinBase,
+            params Assembly[] assemblies)
+            : base(addinBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), new ExcelViewContextProvider(), null, ExcelRibbonType.ExcelWorkbook.GetEnumDescription())
+        {
+        }
+
+        public ExcelRibbonFactory(AddInBase addinBase,
+            IViewLocationStrategy viewLocationStrategy,
+            params Assembly[] assemblies)
+            : base(addinBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), new ExcelViewContextProvider(), viewLocationStrategy, ExcelRibbonType.ExcelWorkbook.GetEnumDescription())
         {
         }
 
         protected override void InitialiseRibbonFactoryController(IRibbonFactoryController controller, object application)
         {
-            var app = (Application) application;
+            var app = (Application)application;
             excelViewProvider = new ExcelViewProvider(app);
             controller.Initialise(excelViewProvider);
             excelViewProvider.RegisterOpenDocuments();

--- a/src/VSTOContrib.Outlook/RibbonFactory/OutlookRibbonFactory.cs
+++ b/src/VSTOContrib.Outlook/RibbonFactory/OutlookRibbonFactory.cs
@@ -20,7 +20,15 @@ namespace VSTOContrib.Outlook.RibbonFactory
         public OutlookRibbonFactory(
             AddInBase addinBase,
             params Assembly[] assemblies)
-            : base(addinBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), new OutlookViewContextProvider(), null)
+            : base(addinBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), new OutlookViewContextProvider(), null, null)
+        {
+        }
+
+        public OutlookRibbonFactory(
+            AddInBase addinBase,
+            IViewLocationStrategy viewLocationStrategy,
+            params Assembly[] assemblies)
+            : base(addinBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), new OutlookViewContextProvider(), viewLocationStrategy, null)
         {
         }
 
@@ -29,7 +37,7 @@ namespace VSTOContrib.Outlook.RibbonFactory
         /// </summary>
         protected override void InitialiseRibbonFactoryController(IRibbonFactoryController controller, object application)
         {
-            viewProvider = new OutlookViewProvider((_Application) application);
+            viewProvider = new OutlookViewProvider((_Application)application);
 
             controller.Initialise(viewProvider);
         }

--- a/src/VSTOContrib.PowerPoint/RibbonFactory/PowerPointRibbonFactory.cs
+++ b/src/VSTOContrib.PowerPoint/RibbonFactory/PowerPointRibbonFactory.cs
@@ -18,7 +18,15 @@ namespace VSTOContrib.PowerPoint.RibbonFactory
         public PowerPointRibbonFactory(
             AddInBase addInBase,
             params Assembly[] assemblies)
-            : base(addInBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), new PowerPointViewContextProvider(), PowerPointRibbonType.PowerPointPresentation.GetEnumDescription())
+            : base(addInBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), new PowerPointViewContextProvider(), null, PowerPointRibbonType.PowerPointPresentation.GetEnumDescription())
+        {
+        }
+
+        public PowerPointRibbonFactory(
+            AddInBase addInBase,
+            IViewLocationStrategy viewLocationStrategy,
+            params Assembly[] assemblies)
+            : base(addInBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), new PowerPointViewContextProvider(), viewLocationStrategy, PowerPointRibbonType.PowerPointPresentation.GetEnumDescription())
         {
         }
 

--- a/src/VSTOContrib.Word/RibbonFactory/WordRibbonFactory.cs
+++ b/src/VSTOContrib.Word/RibbonFactory/WordRibbonFactory.cs
@@ -15,7 +15,15 @@ namespace VSTOContrib.Word.RibbonFactory
         public WordRibbonFactory(
             AddInBase addinBase,
             params Assembly[] assemblies)
-            : base(addinBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), new WordViewContextProvider(), WordRibbonType.WordDocument.GetEnumDescription())
+            : base(addinBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), new WordViewContextProvider(), null, WordRibbonType.WordDocument.GetEnumDescription())
+        {
+        }
+
+        public WordRibbonFactory(
+            AddInBase addinBase,
+            IViewLocationStrategy viewLocationStrategy,
+            params Assembly[] assemblies)
+            : base(addinBase, UseIfEmpty(assemblies, Assembly.GetCallingAssembly()), new WordViewContextProvider(), viewLocationStrategy, WordRibbonType.WordDocument.GetEnumDescription())
         {
         }
 


### PR DESCRIPTION
- IViewLocationStrategy injected through constructor of RibbonFactory to VstoContribContext (fall back to DefaultViewLocationStrategy if null)
- changed IRibbonFactory LocateViewStrategy property to getter only as value of property is used on RibbonFactory construction time only
- added constructor overload for all classes inherited from RibbonFactory