### PR TITLE
Do not add DefaultRibbon to ribbonUiLookup if it is already there.

### DIFF
--- a/src/VSTOContrib.Core/RibbonFactory/Internal/ViewModelResolver.cs
+++ b/src/VSTOContrib.Core/RibbonFactory/Internal/ViewModelResolver.cs
@@ -81,10 +81,9 @@ namespace VSTOContrib.Core.RibbonFactory.Internal
         {
             VstoContribLog.Debug(_ => _("ViewProvider.NewView Raised, Type: {0}, View: {1}, Context: {2}",
                 e.RibbonType, e.ViewInstance.ToLogFormat(), e.ViewContext.ToLogFormat()));
-            if (ribbonUiLookup.ContainsKey("default"))
+            if (!ribbonUiLookup.ContainsKey(e.RibbonType) && ribbonUiLookup.ContainsKey(DefaultRibbon))
             {
-                ribbonUiLookup.Add(e.RibbonType, ribbonUiLookup["default"]);
-                ribbonUiLookup.Remove("default");
+                ribbonUiLookup.Add(e.RibbonType, ribbonUiLookup[DefaultRibbon]);
             }
             var viewModel = GetOrCreateViewModel(e.RibbonType, e.ViewContext ?? NullContext.Instance, e.ViewInstance);
             if (viewModel == null) return;


### PR DESCRIPTION
ViewProviderNewView was throwing an exception if ribbonUiLookup already contained a value for DefaultRibbon.  Additionally, ribbonUiLookup no longer deletes the value for DefaultRibbon after it is inserted because it may be needed later by BuildViewModel.